### PR TITLE
Adds completion::Shell implementations of serde::{Serialize, Deserialize}

### DIFF
--- a/src/completion.rs
+++ b/src/completion.rs
@@ -7,6 +7,7 @@ use clap_complete::{aot::Shell as ClapShell, generate};
 use std::{fmt, io, str::FromStr};
 
 /// Shell names that provide autocompletion support
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
 pub enum Shell {
     /// Bourne Again shell (bash)

--- a/src/completion.rs
+++ b/src/completion.rs
@@ -118,7 +118,7 @@ mod shell_serde {
             D: Deserializer<'de>,
         {
             let s = <&str>::deserialize(deserializer)?;
-            Shell::from_str(s).map_err(|e| de::Error::custom(e))
+            Shell::from_str(s).map_err(de::Error::custom)
         }
     }
 }

--- a/src/completion.rs
+++ b/src/completion.rs
@@ -7,7 +7,6 @@ use clap_complete::{aot::Shell as ClapShell, generate};
 use std::{fmt, io, str::FromStr};
 
 /// Shell names that provide autocompletion support
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
 pub enum Shell {
     /// Bourne Again shell (bash)
@@ -23,6 +22,37 @@ pub enum Shell {
 }
 
 impl Shell {
+    /// help text to show the list of completions
+    pub const EXPECTED: &'static str = "bash, elvish, fish, powershell, zsh";
+
+    #[inline]
+    /// convert option to string name
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Shell::Bash => "bash",
+            Shell::Elvish => "elvish",
+            Shell::Fish => "fish",
+            Shell::PowerShell => "powershell",
+            Shell::Zsh => "zsh",
+        }
+    }
+
+    /// Parse a shell name (case-insensitive, trims whitespace).
+    #[inline]
+    pub fn parse(s: &str) -> Result<Self, ParseShellError> {
+        let v = s.trim().to_ascii_lowercase();
+        match v.as_str() {
+            "bash" => Ok(Shell::Bash),
+            "elvish" => Ok(Shell::Elvish),
+            "fish" => Ok(Shell::Fish),
+            "powershell" => Ok(Shell::PowerShell),
+            "zsh" => Ok(Shell::Zsh),
+            _ => Err(ParseShellError {
+                input: s.to_string(),
+            }),
+        }
+    }
+
     #[inline]
     fn to_clap(self) -> ClapShell {
         match self {
@@ -45,8 +75,9 @@ impl fmt::Display for ParseShellError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(
             f,
-            "invalid shell {:?} (expected: bash, elvish, fish, powershell, zsh)",
-            self.input
+            "invalid shell {:?} (expected: {})",
+            self.input,
+            Shell::EXPECTED
         )
     }
 }
@@ -57,29 +88,38 @@ impl FromStr for Shell {
     type Err = ParseShellError;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        let v = s.trim().to_ascii_lowercase();
-        match v.as_str() {
-            "bash" => Ok(Shell::Bash),
-            "elvish" => Ok(Shell::Elvish),
-            "fish" => Ok(Shell::Fish),
-            "powershell" => Ok(Shell::PowerShell),
-            "zsh" => Ok(Shell::Zsh),
-            _ => Err(ParseShellError {
-                input: s.to_string(),
-            }),
-        }
+        Shell::parse(s)
     }
 }
 
 impl fmt::Display for Shell {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.write_str(match self {
-            Shell::Bash => "bash",
-            Shell::Elvish => "elvish",
-            Shell::Fish => "fish",
-            Shell::PowerShell => "powershell",
-            Shell::Zsh => "zsh",
-        })
+        f.write_str(self.as_str())
+    }
+}
+
+#[cfg(feature = "serde")]
+mod shell_serde {
+    use super::*;
+    use serde::{Deserialize, Deserializer, Serialize, Serializer, de};
+
+    impl Serialize for Shell {
+        fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+        where
+            S: Serializer,
+        {
+            serializer.serialize_str(self.as_str())
+        }
+    }
+
+    impl<'de> Deserialize<'de> for Shell {
+        fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+        where
+            D: Deserializer<'de>,
+        {
+            let s = <&str>::deserialize(deserializer)?;
+            Shell::from_str(s).map_err(|e| de::Error::custom(e))
+        }
     }
 }
 


### PR DESCRIPTION
Fixes #32 

If the `completion` *and* `serde` feature is enabled, the completion::Shell enum should implement serde::Serialize and serde::Deserialize.